### PR TITLE
Update infrastructure setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,26 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:04"
+      timezone: "Europe/London"
+
 updates:
+  # main dependencies
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: wednesday
+      interval: "daily"
+      time: "10:30"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "uk.gov.justice.service.hmpps:*"
+        - "uk.gov.justice.hmpps.*"
     groups:
       minor:
         update-types:
@@ -13,15 +29,37 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "github-actions"
+  # infrastructure dependencies
+  - package-ecosystem: "docker"
+    multi-ecosystem-group: "infrastructure"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: wednesday
-    groups:
-      minor:
-        update-types:
-          - "minor"
-          - "patch"
-        patterns:
-          - "*"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "docker-compose"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "ministryofjustice/*"
+  - package-ecosystem: "helm"
+    multi-ecosystem-group: "infrastructure"
+    directories:
+      - "/helm_deploy/*"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "https://ministryofjustice.github.io/hmpps-helm-charts/*"

--- a/.github/workflows/security_codeql_actions_scan.yml
+++ b/.github/workflows/security_codeql_actions_scan.yml
@@ -2,7 +2,8 @@ name: Security CodeQL actions scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "8 10 * * MON-FRI" # Every weekday
+    - cron: "8 10 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-codeql-actions-check:

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -2,7 +2,8 @@ name: Security OWASP dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "8 10 * * MON-FRI" # Every weekday
+    - cron: "8 10 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-kotlin-owasp-check:

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -22,5 +22,6 @@ jobs:
       slack_include_summary: true
       snyk_policy_path: '' # Optional path to a custom Snyk policy file
     secrets:
-      HMPPS_SNYK_API_KEY: ${{ secrets.HMPPS_SNYK_API_KEY }}
+      HMPPS_SNYK_CLIENT_SECRET: ${{ secrets.HMPPS_SNYK_CLIENT_SECRET }}
+      HMPPS_SNYK_CLIENT_ID: ${{ secrets.HMPPS_SNYK_CLIENT_ID }}
       HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -13,7 +13,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security Snyk dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v3
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       subproject: ''

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -3,7 +3,8 @@ name: Security Snyk dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "14 13 * * 1-5"
+    - cron: "14 13 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-snyk-check:
@@ -12,7 +13,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security Snyk dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v3
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       subproject: ''

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -2,7 +2,8 @@ name: Security veracode pipeline scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "8 10 * * MON-FRI" # Every weekday
+    - cron: "8 10 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-veracode-pipeline-scan:

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -2,7 +2,8 @@ name: Security veracode policy scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "25 3 * * 1" # Every Monday
+    - cron: "25 3 * * MON"
+      timezone: "Europe/London"
 
 jobs:
   security-veracode-policy-check:

--- a/helm_deploy/hmpps-person-communication-needs-api/Chart.yaml
+++ b/helm_deploy/hmpps-person-communication-needs-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-person-communication-needs-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.15"
+    version: "3.17"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: "1.17"


### PR DESCRIPTION
- dependency updates for infrastructure are grouped into 1 and main dependencies are checked on weekdays
- latest HMPPS helm `generic-service` chart
- snyk now uses oauth instead of api token